### PR TITLE
allows to set a class on a legend item

### DIFF
--- a/demo/component/Legend.js
+++ b/demo/component/Legend.js
@@ -22,6 +22,13 @@ const data3 = [
   { value: 'Sony', type: 'line', color: '#ff7812' },
 ];
 
+const data4 = [
+  { value: 'Apple', type: 'line', color: '#ff7300', className: 'disabled' },
+  { value: 'Samsung', type: 'line', color: '#bb7300' },
+  { value: 'Huawei', type: 'line', color: '#bb7300' },
+  { value: 'Sony', type: 'line', color: '#ff7812' },
+];
+
 export default React.createClass({
   render () {
     return (
@@ -37,8 +44,11 @@ export default React.createClass({
         <div style={{ position: 'relative', height: 200 }}>
           <Legend width={200} height={30} payload={data3} />
         </div>
+
+        <div style={{ position: 'relative', height: 200 }}>
+          <Legend width={200} height={30} payload={data4} />
+        </div>
       </div>
     );
   }
 });
-

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,6 +1,11 @@
 <html>
   <head>
     <title>Recharts Demo</title>
+    <style media="screen">
+      li.disabled {
+        opacity: .5;
+      }
+    </style>
   </head>
   <body>
     <div id="root">

--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -23,9 +23,9 @@ class DefaultLegendContent extends Component {
       value: PropTypes.any,
       id: PropTypes.any,
       type: PropTypes.oneOf([
-        'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square',
-        'star', 'triangle', 'wye',
+        'circle', 'cross', 'diamond', 'line', 'rect', 'square', 'star', 'triangle', 'wye',
       ]),
+      className: PropTypes.string,
     })),
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
@@ -99,19 +99,26 @@ class DefaultLegendContent extends Component {
     };
     const svgStyle = { display: 'inline-block', verticalAlign: 'middle', marginRight: 4 };
 
-    return payload.map((entry, i) => (
-      <li
-        className={`recharts-legend-item legend-item-${i}`}
-        style={itemStyle}
-        key={`legend-item-${i}`}
-        {...filterEventsOfChild(this.props, entry, i)}
-      >
-        <Surface width={iconSize} height={iconSize} viewBox={viewBox} style={svgStyle}>
-          {this.renderIcon(entry, iconSize)}
-        </Surface>
-        <span className="recharts-legend-item-text">{entry.value}</span>
-      </li>
-    ));
+    return payload.map((entry, i) => {
+      let className = `recharts-legend-item legend-item-${i}`;
+      if (typeof entry.className === 'string' && entry.className.length > 0) {
+        className += ` ${entry.className}`;
+      }
+
+      return (
+        <li
+          className={className}
+          style={itemStyle}
+          key={`legend-item-${i}`}
+          {...filterEventsOfChild(this.props, entry, i)}
+        >
+          <Surface width={iconSize} height={iconSize} viewBox={viewBox} style={svgStyle}>
+            {this.renderIcon(entry, iconSize)}
+          </Surface>
+          <span className="recharts-legend-item-text">{entry.value}</span>
+        </li>
+      );
+    });
   }
 
   render() {

--- a/src/component/Legend.js
+++ b/src/component/Legend.js
@@ -45,9 +45,9 @@ class Legend extends Component {
       value: PropTypes.any,
       id: PropTypes.any,
       type: PropTypes.oneOf([
-        'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square',
-        'star', 'triangle', 'wye',
+        'circle', 'cross', 'diamond', 'line', 'rect', 'square', 'star', 'triangle', 'wye',
       ]),
+      className: PropTypes.string,
     })),
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,

--- a/test/specs/component/LegendSpec.js
+++ b/test/specs/component/LegendSpec.js
@@ -9,7 +9,7 @@ describe('<Legend />', () => {
     { value: 'Apple', color: '#ff7300' },
     { value: 'Samsung', color: '#bb7300' },
     { value: 'Huawei', color: '#887300' },
-    { value: 'Sony', color: '#667300' },
+    { value: 'Sony', color: '#667300', className: 'someCSSClass' },
   ];
 
   it('Render 4 legend items in simple Legend', () => {
@@ -22,14 +22,22 @@ describe('<Legend />', () => {
   });
 
   it('Render customized legend when content is set to be a react element', () => {
-    const CustomizedLegend = () => {
-      return <div className="customized-legend">test</div>;
-    };
+    const CustomizedLegend = () => <div className="customized-legend">test</div>;
+
     const wrapper = render(
-      <Legend width={500} height={30} payload={data} content={<CustomizedLegend/>}/>
+      <Legend width={500} height={30} payload={data} content={<CustomizedLegend />} />
     );
 
     expect(wrapper.find('.recharts-default-legend').length).to.equal(0);
     expect(wrapper.find('.customized-legend').length).to.equal(1);
   });
+
+  it('Render 4 legend items, one of them has a custom css class', () => {
+    const wrapper = render(
+      <Legend width={500} height={30} payload={data} />
+    );
+
+    expect(wrapper.find('.someCSSClass').length).to.equal(1);
+  });
+
 });


### PR DESCRIPTION
**Why**

I need to customize the legend items. In my case, I've added the ability to toggle elements from a chart and I want to style legend items accordingly.
I could have created a custom Legend component for that, but I think it's a nice feature to add to the default one.

**How**

This PR makes it possible by adding a className attribute to the payload property in the Legend component. If set, this string is appended to the other classes on the li element.

- Tests are passing

@ravasthi PTAL
cc @akvanhar 